### PR TITLE
added openapi-ghec as prod dependency 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
-  "name": "mock-github",
-  "version": "1.0.0",
+  "name": "@kie/mock-github",
+  "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "mock-github",
-      "version": "1.0.0",
+      "name": "@kie/mock-github",
+      "version": "0.0.0",
       "license": "ISC",
       "dependencies": {
+        "@octokit/openapi-types-ghec": "^14.0.0",
         "@rollup/plugin-commonjs": "^22.0.2",
         "@rollup/plugin-node-resolve": "^13.3.0",
         "@rollup/plugin-typescript": "^8.3.4",
@@ -23,7 +24,6 @@
       },
       "devDependencies": {
         "@actions/artifact": "^1.1.0",
-        "@octokit/openapi-types-ghec": "^14.0.0",
         "@octokit/rest": "^19.0.4",
         "@types/express": "^4.17.13",
         "@types/fs-extra": "^9.0.13",
@@ -1372,8 +1372,7 @@
     "node_modules/@octokit/openapi-types-ghec": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types-ghec/-/openapi-types-ghec-14.0.0.tgz",
-      "integrity": "sha512-xhd9oEvn2aroGn+sk09Ptx/76Y7aKU0EIgHukHPCU1+rGJreO36baEEk6k8ZPblieHNM39FcykJQmtDrETm0KA==",
-      "dev": true
+      "integrity": "sha512-xhd9oEvn2aroGn+sk09Ptx/76Y7aKU0EIgHukHPCU1+rGJreO36baEEk6k8ZPblieHNM39FcykJQmtDrETm0KA=="
     },
     "node_modules/@octokit/plugin-paginate-rest": {
       "version": "4.3.1",
@@ -8507,8 +8506,7 @@
     "@octokit/openapi-types-ghec": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types-ghec/-/openapi-types-ghec-14.0.0.tgz",
-      "integrity": "sha512-xhd9oEvn2aroGn+sk09Ptx/76Y7aKU0EIgHukHPCU1+rGJreO36baEEk6k8ZPblieHNM39FcykJQmtDrETm0KA==",
-      "dev": true
+      "integrity": "sha512-xhd9oEvn2aroGn+sk09Ptx/76Y7aKU0EIgHukHPCU1+rGJreO36baEEk6k8ZPblieHNM39FcykJQmtDrETm0KA=="
     },
     "@octokit/plugin-paginate-rest": {
       "version": "4.3.1",

--- a/package.json
+++ b/package.json
@@ -23,11 +23,10 @@
     "update-all": "npm-run-all update:*",
     "file": "ts-node"
   },
-  "author": "",
+  "author": "Shubh Bapna <sbapna@redhat.com>",
   "license": "ISC",
   "devDependencies": {
     "@actions/artifact": "^1.1.0",
-    "@octokit/openapi-types-ghec": "^14.0.0",
     "@octokit/rest": "^19.0.4",
     "@types/express": "^4.17.13",
     "@types/fs-extra": "^9.0.13",
@@ -48,6 +47,7 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
+    "@octokit/openapi-types-ghec": "^14.0.0",
     "@rollup/plugin-commonjs": "^22.0.2",
     "@rollup/plugin-node-resolve": "^13.3.0",
     "@rollup/plugin-typescript": "^8.3.4",


### PR DESCRIPTION
When installing the library from npm registry, typescript was complaining that it couldn't find types for `MoctokitResponse`. Upon investigating the files installed from the registry, it seems that `@octokit/openapi-types-ghec` was not bundled in the type files and is still required as dependency. 