### PR TITLE
binded objects to methods that were exposed by other classes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kie/mock-github",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kie/mock-github",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A bunch of tools to configure and create a local github environment to test your github actions in without having to clutter your github with test repositories, actions or hitting github api rate limits.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/src/github/action/action-mocker.ts
+++ b/src/github/action/action-mocker.ts
@@ -1,5 +1,8 @@
 import { Mocker } from "@mg/github/mocker";
-import { Action, ActionMockerMethods } from "@mg/github/action/action-mocker.types";
+import {
+  Action,
+  ActionMockerMethods,
+} from "@mg/github/action/action-mocker.types";
 import { ArchiveArtifactsMocker } from "@mg/github/action/archive/archive-mocker";
 import { ArchiveArtifactsMockerMethods } from "@mg/github/action/archive/archive-mocker.types";
 import { InputMocker } from "@mg/github/action/input/input-mocker";
@@ -33,16 +36,20 @@ export class ActionMocker implements Mocker, ActionMockerMethods {
 
   get input(): InputMockerMethods {
     return {
-      get: this.inputMocker.get,
-      delete: this.inputMocker.delete,
-      update: this.inputMocker.update,
+      get: this.inputMocker.get.bind(this.inputMocker),
+      delete: this.inputMocker.delete.bind(this.inputMocker),
+      update: this.inputMocker.update.bind(this.inputMocker),
     };
   }
 
   get archiver(): ArchiveArtifactsMockerMethods {
     return {
-      getArtifactStore: this.archiveArtifactsMocker.getArtifactStore,
-      getRunId: this.archiveArtifactsMocker.getRunId,
+      getArtifactStore: this.archiveArtifactsMocker.getArtifactStore.bind(
+        this.archiveArtifactsMocker
+      ),
+      getRunId: this.archiveArtifactsMocker.getRunId.bind(
+        this.archiveArtifactsMocker
+      ),
     };
   }
 }

--- a/src/github/github-mocker.ts
+++ b/src/github/github-mocker.ts
@@ -62,9 +62,9 @@ export class MockGithub implements Mocker {
       throw new Error("Env has not been setup");
     }
     return {
-      update: this.envMocker.update,
-      delete: this.envMocker.delete,
-      get: this.envMocker.get,
+      update: this.envMocker.update.bind(this.envMocker),
+      delete: this.envMocker.delete.bind(this.envMocker),
+      get: this.envMocker.get.bind(this.envMocker),
     };
   }
 


### PR DESCRIPTION
When accessing `env` methods via the MockGithub object I discovered that the internal `env` store was coming up as undefined. 
This PR fixes that issue