### PR TITLE
adds support for relative setupPath

### DIFF
--- a/src/github/github-mocker.ts
+++ b/src/github/github-mocker.ts
@@ -1,14 +1,14 @@
 import { ActionMocker } from "@mg/github/action/action-mocker";
+import { ActionMockerMethods } from "@mg/github/action/action-mocker.types";
 import { EnvMocker } from "@mg/github/env/env-mocker";
+import { EnvMethods } from "@mg/github/env/env-mocker.types";
 import { Config } from "@mg/github/github-mocker.types";
 import { Mocker } from "@mg/github/mocker";
 import { RepositoryMocker } from "@mg/github/repository/repository-mocker";
-import { readFileSync, mkdirSync, existsSync, rmSync } from "fs-extra";
-import { EnvMethods } from "@mg/github/env/env-mocker.types";
-import { ActionMockerMethods } from "@mg/github/action/action-mocker.types";
 import { RepositoryStateMethods } from "@mg/github/repository/state/repository-state.types";
-import Ajv from "ajv";
 import { GithubConfigSchema } from "@mg/github/schema/github";
+import Ajv from "ajv";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "fs-extra";
 import path from "path";
 
 export class MockGithub implements Mocker {
@@ -55,7 +55,7 @@ export class MockGithub implements Mocker {
     ]);
 
     // rm the setup dir only if we had created it
-    if (this.setupDirCreated) {rmSync(this.setupPath, { recursive: true });}
+    if (this.setupDirCreated) { rmSync(this.setupPath, { recursive: true }); }
 
     this.hasCalledSetup = false;
   }

--- a/src/github/github-mocker.ts
+++ b/src/github/github-mocker.ts
@@ -9,6 +9,7 @@ import { ActionMockerMethods } from "@mg/github/action/action-mocker.types";
 import { RepositoryStateMethods } from "@mg/github/repository/state/repository-state.types";
 import Ajv from "ajv";
 import { GithubConfigSchema } from "@mg/github/schema/github";
+import path from "path";
 
 export class MockGithub implements Mocker {
   private actionMocker: ActionMocker;
@@ -21,7 +22,9 @@ export class MockGithub implements Mocker {
 
   constructor(config: string | Config, setupPath: string = process.cwd()) {
     this.config = this.validateConfig(config);
-    this.setupPath = setupPath;
+    this.setupPath = setupPath.startsWith("/")
+      ? setupPath
+      : path.resolve(process.cwd(), setupPath);
     this.actionMocker = new ActionMocker(this.config.action, this.setupPath);
     this.envMocker = new EnvMocker(this.config.env);
     this.repoMocker = new RepositoryMocker(this.config.repo, this.setupPath);


### PR DESCRIPTION
Passing a relative value to as `setupPath` would cause a an error when pushing to the git repo. I added a check to resolve the `setupPath` if it is not absolute.

Before, this ...

```js
const gh = new MockGithub(ghConfig, '_github_mock');
```

... would cause this ...

>     Pushing to _github_mock/repo/test/remote/origin
>     fatal: '_github_mock/repo/test/remote/origin' does not appear to be a git repository
>     fatal: Could not read from remote repository.
> 
>     Please make sure you have the correct access rights
>     and the repository exists.

It could have been fixed by doing ...

```js
const gh = new MockGithub(ghConfig, path.resolve(process.cwd(), '_github_mock'));
```

... but that shouldn't really be necessary from a user's perspective.