### PR TITLE
feat: add an abstract endpoint mocker that contains common methods for all implementations

### DIFF
--- a/src/endpoint-mocker/abstract-endpoint-mocker.ts
+++ b/src/endpoint-mocker/abstract-endpoint-mocker.ts
@@ -1,0 +1,13 @@
+import nock from "nock";
+
+export abstract class EndpointMocker {
+  constructor(private _allowUnmocked: boolean) {}
+
+  get allowUnmocked() {
+    return this._allowUnmocked;
+  } 
+
+  cleanAll() {
+    nock.cleanAll();
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { Input } from "@mg/github/action/input/input-mocker.types";
 import { Response } from "@mg/endpoint-mocker/response/abstract-response-mocker.types";
 import { ResponseMocker } from "@mg/endpoint-mocker/response/abstract-response-mocker";
 import { RequestMocker } from "@mg/endpoint-mocker/request/abstract-request-mocker";
+import { EndpointMocker } from "@mg/endpoint-mocker/abstract-endpoint-mocker";
 import { EndpointDetails, EndpointMethod, Endpoints } from "@mg/endpoint-mocker/endpoint-mocker.types";
 import { Repository, Repositories } from "@mg/github/repository/repository-mocker.types";
 
@@ -36,6 +37,7 @@ export {
   Repositories,
   Repository,
   Response,
+  EndpointMocker,
   ResponseMocker,
   RequestMocker,
   EndpointDetails,

--- a/src/moctokit/moctokit.ts
+++ b/src/moctokit/moctokit.ts
@@ -1,17 +1,14 @@
+import { EndpointMocker } from "@mg/endpoint-mocker/abstract-endpoint-mocker";
 import endpointToMethod from "@mg/moctokit/generated/endpoint-request";
-import nock from "nock";
 
-export class Moctokit {
+export class Moctokit extends EndpointMocker {
   private _rest;
   constructor(baseUrl?: string, allowUnmocked = false) {
-    this._rest = endpointToMethod(baseUrl ?? "https://api.github.com", allowUnmocked);
+    super(allowUnmocked);
+    this._rest = endpointToMethod(baseUrl ?? "https://api.github.com", this.allowUnmocked);
   }
 
   get rest() {
     return this._rest;
-  }
-
-  cleanAll() {
-    nock.cleanAll();
   }
 }


### PR DESCRIPTION
This common interface will contains methods such `cleanAll` and data such as `allowUnmocked`